### PR TITLE
[support][telescope.nvim] add highlights for normal/matching/selection

### DIFF
--- a/lua/lush_theme/karonda.lua
+++ b/lua/lush_theme/karonda.lua
@@ -407,18 +407,23 @@ local theme = lush(function()
     -- TSTypeBuiltin        { } , -- Built-in types: `i32` in Rust.
     -- TSVariable           { } , -- Variable names that don't fit into other categories.
     -- TSVariableBuiltin    { } , -- Variable names defined by the language: `this` or `self` in Javascript.
+    --
+    --
     -- PLUGIN: hrsh7th/nvim-cmp
     -- reference: https://www.github.com/hrsh7th/nvim-cmp/wiki/Menu-Appearance
     CmpItemAbbrDeprecated {
       gui = 'strikethrough',
       fg = palette.aux.error
-    },
+    }, -- deprecated completeopts
     CmpItemAbbrMatch {
       fg = palette.red
-    },
+    }, -- exact matches
     CmpItemAbbrMatchFuzzy {
       fg = palette.pink
-    }, -- PLUGIN: nvim-telescope/telescope.nvim
+    }, -- fuzzy matches
+    --
+    --
+    -- PLUGIN: nvim-telescope/telescope.nvim
     -- reference: telescope.builtin.highlights
     TelescopeNormal {
       fg = palette.foreground.dark
@@ -429,7 +434,7 @@ local theme = lush(function()
     TelescopeSelection {
       fg = palette.pink,
       bg = 'none',
-      gui='bold'
+      gui = 'bold'
     }
   }
 end)

--- a/lua/lush_theme/karonda.lua
+++ b/lua/lush_theme/karonda.lua
@@ -412,10 +412,24 @@ local theme = lush(function()
     CmpItemAbbrDeprecated {
       gui = 'strikethrough',
       fg = palette.aux.error
-    }, CmpItemAbbrMatch {
+    },
+    CmpItemAbbrMatch {
       fg = palette.red
-    }, CmpItemAbbrMatchFuzzy {
+    },
+    CmpItemAbbrMatchFuzzy {
       fg = palette.pink
+    }, -- PLUGIN: nvim-telescope/telescope.nvim
+    -- reference: telescope.builtin.highlights
+    TelescopeNormal {
+      fg = palette.foreground.dark
+    }, -- regular text and colors
+    TelescopeMatching {
+      fg = palette.foreground.light
+    }, -- fuzzy matches
+    TelescopeSelection {
+      fg = palette.pink,
+      bg = 'none',
+      gui='bold'
     }
   }
 end)


### PR DESCRIPTION
add highlights for normal/matching/selection.

```lua
    TelescopeNormal {
      fg = palette.foreground.dark
    }, -- regular text and colors
    TelescopeMatching {
      fg = palette.foreground.light
    }, -- fuzzy matches
    TelescopeSelection {
      fg = palette.pink,
      bg = 'none',
      gui='bold'
    }
```
old:
![Screen Shot 2022-03-27 at 1 25 29 PM](https://user-images.githubusercontent.com/37908451/160299531-458312ee-12e5-4a7e-b568-e33e283e73df.png)

new: 
![Screen Shot 2022-03-27 at 1 25 07 PM](https://user-images.githubusercontent.com/37908451/160299518-e15db47d-473d-4ed1-b560-1623c2acc018.png)

